### PR TITLE
github action to help synchronizing with Bioconductor remote

### DIFF
--- a/.github/workflows/biocrelease.yaml
+++ b/.github/workflows/biocrelease.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: "30 13 * * *"
+    - cron: "35 13 * * *"
 
 name: syncronise-bioconductor-release
 

--- a/.github/workflows/biocrelease.yaml
+++ b/.github/workflows/biocrelease.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.ref}}
@@ -17,13 +17,18 @@ jobs:
 
       - name: Make PR
         run: |
-          BIOC_REMOTE=''
-          GH_REMOTE=''
-          LATEST_BIOC_TAG=`git ls-remote ${BIOC_REMOTE} HEAD`
-          LATEST_GH_TAG=`git ls-remote ${GH_REMOTE} HEAD`
-          [[ ${LATEST_BIOC_TAG} == ${LATEST_GH_TAG} ]] && exit 0
+          BIOC_REMOTE='git@git.bioconductor.org:packages/midasHLA'
+          MAIN_BRANCH='master'
+          COMMIT_TITLE='New Bioconductor release'
+          gitlog() {
+            git --no-pager log --pretty=format:'%h' ${@}
+          }
+          git remote add bioconductor ${BIOC_REMOTE}
+          git fetch bioconductor
+          BIOC_TAG=`gitlog bioconductor/master -1`
+          COMMIT_BODY=`git --no-pager log bioconductor/master --pretty=format:'%s' -1`
+          gitlog ${MAIN_BRANCH}
+          gitlog ${MAIN_BRANCH} | grep -q -e ${BIOC_TAG} && exit 0
+          git checkout bioconductor/master
+          gh pr create --base master --title ${COMMIT_TITLE} --body ${COMMIT_BODY}
           
-
-          
-          
-      

--- a/.github/workflows/biocrelease.yaml
+++ b/.github/workflows/biocrelease.yaml
@@ -1,0 +1,29 @@
+on:
+  cron: "* * * * *"
+
+name: syncronise-bioconductor-release
+
+jobs:
+  send-pull-requests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@
+        with:
+          fetch-depth: 0
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Make PR
+        run: |
+          BIOC_REMOTE=''
+          GH_REMOTE=''
+          LATEST_BIOC_TAG=`git ls-remote ${BIOC_REMOTE} HEAD`
+          LATEST_GH_TAG=`git ls-remote ${GH_REMOTE} HEAD`
+          [[ ${LATEST_BIOC_TAG} == ${LATEST_GH_TAG} ]] && exit 0
+          
+
+          
+          
+      

--- a/.github/workflows/biocrelease.yaml
+++ b/.github/workflows/biocrelease.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: "14 * * * *"
+    - cron: "30 13 * * *"
 
 name: syncronise-bioconductor-release
 
@@ -15,10 +15,11 @@ jobs:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Make PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BIOC_REMOTE='git@git.bioconductor.org:packages/midasHLA'
+          BIOC_REMOTE='https://git.bioconductor.org/packages/xcore'
           MAIN_BRANCH='master'
           COMMIT_TITLE='New Bioconductor release'
           gitlog() {
@@ -28,8 +29,7 @@ jobs:
           git fetch bioconductor
           BIOC_TAG=`gitlog bioconductor/master -1`
           COMMIT_BODY=`git --no-pager log bioconductor/master --pretty=format:'%s' -1`
-          gitlog ${MAIN_BRANCH}
-          gitlog ${MAIN_BRANCH} | grep -q -e ${BIOC_TAG} && exit 0
-          git checkout bioconductor/master
-          gh pr create --base master --title ${COMMIT_TITLE} --body ${COMMIT_BODY}
-          
+          if [[ gitlog ${MAIN_BRANCH} | grep -q -e ${BIOC_TAG} ]]; then
+            git checkout bioconductor/master
+            gh pr create --base master --title "${COMMIT_TITLE}" --body "${COMMIT_BODY}"
+          fi

--- a/.github/workflows/biocrelease.yaml
+++ b/.github/workflows/biocrelease.yaml
@@ -1,5 +1,6 @@
 on:
-  cron: "* * * * *"
+  schedule:
+    - cron: "14 * * * *"
 
 name: syncronise-bioconductor-release
 


### PR DESCRIPTION
Addressing #27, added biocrelease.yaml. At fixed intervals it checks the Bioconductor remote latest commit hash and compares history on Github remote. If there are there is anything new (eg. the release version bump) action creates a PR on Github.