### PR TITLE
Fixed bug in the hlaToVariable() function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: midasHLA
 Title: R package for immunogenomics data handling and association analysis
-Version: 1.11.0
+Version: 1.11.1
 Authors@R: c(
   person("Christian", "Hammer", email = "hammerc6@gene.com", role = "aut"),
   person("Maciej", "Migdał", email = "mcjmigdal@gmail.com", role = c("aut", "cre")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# 1.11.1 18/01/24
++ Fix bug on hlaToVariable() function that variable would erroneously be named NA.
+
 # 1.5.2 - 25/05/21
 + alleles and KIR frequenceis updated.
 

--- a/R/transformationFunctions.R
+++ b/R/transformationFunctions.R
@@ -289,7 +289,7 @@ hlaToVariable <- function(hla_calls,
   }
 
   variable <- cbind(hla_calls[, 1, drop = FALSE], variable, stringsAsFactors = FALSE)
-  colnames(variable) <- c("ID", colnames(variable[, -1]))
+  colnames(variable) <- c("ID", colnames(variable)[-1])
 
   if (ncol(variable) <= 1) {
     warn("HLA alleles could not be converted to any new variables.")


### PR DESCRIPTION
Naming bug found on `hlaToVariable()` function.
Before the fix, when only getting one new variable annotation with this function, that variable would erroneously be named `NA`. This led to a critical error as `NA` cannot be used as a column index in a tibble for assignment. The error message encountered was:
```
.Error in `[<-`:
! Can't use NA as column index in a tibble for assignment. Backtrace:
  1. midasHLA::prepareMiDAS(...)
  3. midasHLA:::prepareMiDAS_hla_kir_interactions(...)
  6. midasHLA::getHlaKirInteractions(hla_calls = hla_calls, kir_calls = kir_calls)
  7. base::Reduce(...)
  8. midasHLA (local) f(init, x[[i]])
 10. dplyr:::left_join.data.frame(...)
 11. dplyr:::join_mutate(...)
 13. tibble:::`[<-.tbl_df`(`*tmp*`, names(y_out), value = `<tibble[,1]>`)
```

The fix ensures that `prepareMiDAS()` can process single-variable annotations without encountering the mentioned error.
